### PR TITLE
VPC fix for PR #44

### DIFF
--- a/src/game/client/client_hl2_base.vpc
+++ b/src/game/client/client_hl2_base.vpc
@@ -180,6 +180,8 @@ $Project
 			$File	"$SRCDIR\game\shared\hl2\hl2_usermessages.cpp"
 			$File	"$SRCDIR\game\shared\hl2\hl_gamemovement.cpp"
 			$File	"$SRCDIR\game\shared\hl2\hl_gamemovement.h"
+			$File   "$SRCDIR\game\shared\hl2\hl2_playeranimstate.h"
+            $File   "$SRCDIR\game\shared\hl2\hl2_playeranimstate.cpp"
 			$File	"hl2\hl_in_main.cpp"
 			$File	"hl2\hl_prediction.cpp"
 			$File	"hl2\hud_ammo.cpp"

--- a/src/game/client/hl2/c_basehlplayer.h
+++ b/src/game/client/hl2/c_basehlplayer.h
@@ -11,7 +11,7 @@
 #ifdef _WIN32
 #pragma once
 #endif
-
+#define HL2_PLAYERANIMSTATE
 
 #include "c_baseplayer.h"
 #include "c_hl2_playerlocaldata.h"

--- a/src/game/client/hl2/c_basehlplayer.h
+++ b/src/game/client/hl2/c_basehlplayer.h
@@ -1,4 +1,4 @@
-//========= Copyright © 1996-2005, Valve Corporation, All rights reserved. ============//
+//========= Copyright Â© 1996-2005, Valve Corporation, All rights reserved. ============//
 //
 // Purpose: 
 //
@@ -11,7 +11,7 @@
 #ifdef _WIN32
 #pragma once
 #endif
-#define HL2_PLAYERANIMSTATE
+//#define HL2_PLAYERANIMSTATE //uncomment for global hl2_playeranimstate across projects.
 
 #include "c_baseplayer.h"
 #include "c_hl2_playerlocaldata.h"


### PR DESCRIPTION
fixes compile errors caused by missing definitions. Thanks to DankParrot and yikez for catching these errors.