### PR TITLE
Fix C_PortalGhostRenderable

### DIFF
--- a/src/game/client/portal/C_PortalGhostRenderable.cpp
+++ b/src/game/client/portal/C_PortalGhostRenderable.cpp
@@ -11,6 +11,8 @@
 #include "c_portal_player.h"
 #include "model_types.h"
 
+ConVar portal_ghosts_disable( "portal_ghosts_disable", "0", FCVAR_NONE, "Disables rendering of ghosted objects in portal environments" );
+
 C_PortalGhostRenderable::C_PortalGhostRenderable( C_Prop_Portal *pOwningPortal, C_BaseEntity *pGhostSource, const VMatrix &matGhostTransform, float *pSharedRenderClipPlane, bool bLocalPlayer )
 : m_pGhostedRenderable( pGhostSource ), 
 	m_matGhostTransform( matGhostTransform ), 
@@ -224,6 +226,9 @@ bool C_PortalGhostRenderable::GetAttachmentVelocity( int number, Vector &originV
 
 int C_PortalGhostRenderable::DrawModel( int flags, const RenderableInstance_t& instance )
 {
+	if ( portal_ghosts_disable.GetBool() )
+		return 0;
+
 	if( m_bSourceIsBaseAnimating )
 	{
 		if( m_bLocalPlayer )
@@ -261,6 +266,13 @@ int C_PortalGhostRenderable::DrawModel( int flags, const RenderableInstance_t& i
 	}
 
 	return 0;
+}
+
+bool C_PortalGhostRenderable::OnInternalDrawModel( ClientModelRenderInfo_t *pInfo )
+{
+	// TODO: account for m_pGhostedRenderable having a custom lighting origin
+	pInfo->pLightingOrigin = &(m_pGhostedRenderable->GetAbsOrigin());
+	return true;
 }
 
 ModelInstanceHandle_t C_PortalGhostRenderable::GetModelInstance()

--- a/src/game/client/portal/C_PortalGhostRenderable.h
+++ b/src/game/client/portal/C_PortalGhostRenderable.h
@@ -75,6 +75,7 @@ public:
 	virtual float *GetRenderClipPlane( void ) { return m_pSharedRenderClipPlane; };
 
 	virtual int	DrawModel( int flags, const RenderableInstance_t& instance );
+	virtual bool OnInternalDrawModel( ClientModelRenderInfo_t *pInfo );
 
 	// Get the model instance of the ghosted model so that decals will properly draw across portals
 	virtual ModelInstanceHandle_t GetModelInstance();
@@ -118,6 +119,7 @@ public:
 	virtual ICollideable*			GetCollideable() { return NULL; };
 	virtual IClientNetworkable*		GetClientNetworkable() { return NULL; };
 	virtual IClientRenderable*		GetClientRenderable() { return this; };
+	virtual IClientModelRenderable*	GetClientModelRenderable() { return NULL; } // disable fast path
 	virtual IClientEntity*			GetIClientEntity() { return NULL; };
 	virtual C_BaseEntity*			GetBaseEntity() { return NULL; };
 	virtual IClientThinkable*		GetClientThinkable() { return NULL; };


### PR DESCRIPTION
Fixes #15 
- Disables fast path model rendering for ghosts
(this fixes the player model ghost)
- Add convar "portal_ghosts_disable"
- Override ghosts' lighting origins