### PR TITLE
Include VS10-13 under requirements.

### DIFF
--- a/README
+++ b/README
@@ -10,7 +10,8 @@ Features
 Requirements
 -----------------------
 
--MFC Multibyte library for Visual Studio
+- Visual Studio 2010/12/13
+- MFC Multibyte library for Visual Studio
 
 Contributors
 -----------------------


### PR DESCRIPTION
This is in relationship to #62, to perhaps make the requirement of Visual Studio 2010 / 2012 / 2013 a little bit clearer. I realise it's currently stated somewhat under "Features" but the phrasing is a little unclear that installing an earlier version is a requirement before being able to generate project files for a later version (i.e. 2019).